### PR TITLE
add boombox support to non-gf positions, add resetting functions to Boombox

### DIFF
--- a/source/funkin/play/boombox/Boombox.hx
+++ b/source/funkin/play/boombox/Boombox.hx
@@ -18,6 +18,26 @@ class Boombox extends FlxSpriteGroup implements IPlayStateScriptedClass
 {
   public var parentCharacter:Null<BaseCharacter> = null;
 
+  public var originalPosition:FlxPoint = new FlxPoint(0, 0);
+
+  /**
+   * Reset the boombox so it can be used at the start of the level.
+   * Call this when restarting the level.
+   */
+  public function resetBoombox():Void
+  {
+    this.resetPosition();
+  }
+
+  /**
+   * If this Boombox was defined by the stage, return the prop to its original position.
+   */
+  public function resetPosition()
+  {
+    this.x = originalPosition.x;
+    this.y = originalPosition.y;
+  }
+
   public function refresh():Void
   {
     sort(SortUtil.byZIndex, FlxSort.ASCENDING);


### PR DESCRIPTION
This PR adds everything I thought should've been added originally.
It also adds some resetting functions from Bopper, just so its easier to reset.

Also, just in-case, I added resetting to the A-Bot Boombox in this PR: KoloInDaCrib/FunkinAssetsContrib#1